### PR TITLE
Fix delimiter typos in UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@ Note that this switch is incompatible with switch --text-only.">
                             </div>
                             <!-- --param-del -->
                             <div class="form-group" title="There are cases when default parameter delimiter (&) needs to be overwritten for sqlmap to be able to properly split and process each parameter separately (e.g. query=foobar;id=1 instead query=foobar&id=1).">
-                                <label class="form-label" for="paramDel">PARAMETER DELIMETER (--param-del)</label>
+                                <label class="form-label" for="paramDel">PARAMETER DELIMITER (--param-del)</label>
                                 <input type="text" id="paramDel" class="form-control" placeholder="&">
                             </div>
                             <!-- -r -->
@@ -320,7 +320,7 @@ If you provide a HTTP Cookie header with option --cookie and the target URL send
                             </div>
                             <!-- --cookie-del -->
                             <div class="form-group" title="the HTTP Cookie header values are usually separated by a ; character, not by an &. Sqlmap can recognize these as separate sets of parameter=value too, as well as GET and POST parameters. In case that the separation character is other than ; it can be specified by using option --cookie-del">
-                                <label class="form-label" title="HTTP Cookie header value" for="cookieDel">COOKIE DELIMETER (--cookie-del)</label>
+                                <label class="form-label" title="HTTP Cookie header value" for="cookieDel">COOKIE DELIMITER (--cookie-del)</label>
                                 <input type="text" id="cookieDel" class="form-control" placeholder=";">
                             </div>
                             <!-- --live-cookies -->


### PR DESCRIPTION
## Summary
- fix spelling in `PARAMETER DELIMITER` label
- fix spelling in `COOKIE DELIMITER` label

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b149ff7f0832b8393a190b989c827