### PR TITLE
Fix typos in level help text

### DIFF
--- a/app.js
+++ b/app.js
@@ -183,10 +183,10 @@ class SQLMapGenerator {
             let levelHelp = "";
             switch (levelSlider.value) {
                 case "1": levelHelp = "1: Fastest and least intrusive testing of GET and POST parameters (default)."; break;
-                case "2": levelHelp = "2: Additionaly test injections in the Cookie header."; break;
-                case "3": levelHelp = "3: Additionaly test injections in User-Agent and Referer headers ."; break;
-                case "4": levelHelp = "4: Additionaly perform more advbanced tests, such as null values and some extra payloads."; break;
-                case "5": levelHelp = "5: Additionaly test Host header, using all possible payloads."; break;
+                case "2": levelHelp = "2: Additionally test injections in the Cookie header."; break;
+                case "3": levelHelp = "3: Additionally test injections in User-Agent and Referer headers ."; break;
+                case "4": levelHelp = "4: Additionally perform more advanced tests, such as null values and some extra payloads."; break;
+                case "5": levelHelp = "5: Additionally test Host header, using all possible payloads."; break;
             }
             document.getElementById('level-help').textContent = levelHelp;
         });


### PR DESCRIPTION
## Summary
- fix typos in level help descriptions

## Testing
- `grep -r "Additionaly" -n || true`
- `grep -r "advbanced" -n || true`


------
https://chatgpt.com/codex/tasks/task_e_684b1492d620832ba588262c3f0d515b