### PR TITLE
Fix typed constants for copy notifications

### DIFF
--- a/app.js
+++ b/app.js
@@ -574,12 +574,12 @@ class SQLMapGenerator {
         const copyBtn = document.getElementById('copyBtn');
         const copyText = document.getElementById('copyText');
         const txt_command_copy_clipboard = 'COPY COMMAND TO CLIPBOARD';
-        const txt_command_copy_coppied = 'COMMAND COPIED!';
+        const txt_command_copy_copied = 'COMMAND COPIED!';
         
         try {
             await navigator.clipboard.writeText(command);
             copyBtn.classList.add('copying');
-            copyText.textContent = txt_command_copy_coppied;
+            copyText.textContent = txt_command_copy_copied;
             
             setTimeout(() => {
                 copyBtn.classList.remove('copying');
@@ -594,7 +594,7 @@ class SQLMapGenerator {
             document.execCommand('copy');
             document.body.removeChild(textArea);
             
-            copyText.textContent = txt_command_copy_coppied;
+            copyText.textContent = txt_command_copy_copied;
             setTimeout(() => {
                 copyText.textContent = txt_command_copy_clipboard;
             }, 3000);
@@ -607,12 +607,12 @@ class SQLMapGenerator {
         const copyUrlBtn = document.getElementById('copyUrlBtn');
         const copyUrlText = document.getElementById('copyUrlText');
         const txt_command_url_clipboard = 'COPY CONFIG URL';
-        const txt_command_url_coppied = 'URL COPIED!';
+        const txt_command_url_copied = 'URL COPIED!';
 
         try {
             await navigator.clipboard.writeText(command);
             copyUrlBtn.classList.add('copying');
-            copyUrlText.textContent = txt_command_url_coppied;
+            copyUrlText.textContent = txt_command_url_copied;
 
             setTimeout(() => {
                 copyUrlBtn.classList.remove('copying');
@@ -629,7 +629,7 @@ class SQLMapGenerator {
             document.execCommand('copy');
             document.body.removeChild(textArea);
 
-            copyUrlText.textContent = txt_command_url_coppied;
+            copyUrlText.textContent = txt_command_url_copied;
             setTimeout(() => {
                 copyUrlText.textContent = txt_command_url_clipboard;
             }, 3000);


### PR DESCRIPTION
## Summary
- fix typos in copy notification constant names in `app.js`

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6852a6fa73e4832b96debd6dc1b4c712