### PR TITLE
Fix double semicolon in torType handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -296,7 +296,7 @@ class SQLMapGenerator {
         const torPort = document.getElementById('torPort').value.trim();
         if (torPort) config['--tor-port'] = torPort;        
 
-        const torType = document.getElementById('torType').value.trim();;
+        const torType = document.getElementById('torType').value.trim();
         if (torType && torType !== "SOCKS5") config['--tor-type'] = torType;        
 
         // Request options


### PR DESCRIPTION
## Summary
- fix typo in `torType` variable assignment

## Testing
- `python3 build.py`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6852a6f5fce8832b82dcc2ac673b43ae