### PR TITLE
Fix label typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@ Note that this switch is incompatible with switch --text-only.">
                             </div>
                             <!-- --proxy-cred -->
                             <div class="form-group" title="Use a proxy to connect to the target URL">
-                                <label class="form-label" for="proxyCred">HTTP(S) PROXY CREDENTIALS<br/><span>--proxy-creed</span></label>
+                                <label class="form-label" for="proxyCred">HTTP(S) PROXY CREDENTIALS<br/><span>--proxy-cred</span></label>
                                 <input type="text" id="proxyCred" class="form-control" placeholder="username:password">
                             </div>
                             <!-- --proxy-file -->


### PR DESCRIPTION
## Summary
- fix typo in proxy credentials label

## Testing
- `grep -n -- '--proxy-cred' index.html`


------
https://chatgpt.com/codex/tasks/task_e_6852a6dace18832ba3fc6495dbf98ddd